### PR TITLE
修复给钱和支付指令的金额验证

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,15 +23,18 @@
     </properties>
 
     <dependencies>
+        <!-- Nukkit -->
         <dependency>
             <groupId>cn.nukkit</groupId>
             <artifactId>Nukkit</artifactId>
             <version>MOT-SNAPSHOT</version>
-            <scope>provided</scope>
+            <scope>system</scope>
+            <systemPath>${project.basedir}/lib/Nukkit-MOT-SNAPSHOT.jar</systemPath>
         </dependency>
         <dependency>
             <groupId>com.smallaswater.easysqlx</groupId>
             <artifactId>EasySQLX</artifactId>
+
             <version>4.0.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>

--- a/src/main/java/me/onebone/economyapi/command/GiveMoneyCommand.java
+++ b/src/main/java/me/onebone/economyapi/command/GiveMoneyCommand.java
@@ -67,7 +67,7 @@ public class GiveMoneyCommand extends Command {
         }
         try {
             double amount = Double.parseDouble(args[1]);
-            if (amount < 0) {
+            if (amount < 0 || Double.isNaN(amount)) {
                 sender.sendMessage(EconomyAPI.getI18n().tr(langCode, "givemoney-invalid-number"));
                 return true;
             }

--- a/src/main/java/me/onebone/economyapi/command/PayCommand.java
+++ b/src/main/java/me/onebone/economyapi/command/PayCommand.java
@@ -84,7 +84,7 @@ public class PayCommand extends Command {
             return true;
         }
 
-        if (amount < 0.01) {
+        if (amount < 0.01 || Double.isNaN(amount)) {
             sender.sendMessage(EconomyAPI.getI18n().tr(langCode, "pay-too-low"));
             return true;
         }


### PR DESCRIPTION

- 在 GiveMoneyCommand 和 PayCommand 中增加了对 NaN（非数字）金额的检查
- 防止玩家通过输入特殊字符或非法值来利用游戏漏洞